### PR TITLE
Add badge for android-gems.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Android Gems](http://www.android-gems.com/badge/f2prateek/rx-receivers.svg?branch=master)](http://www.android-gems.com/lib/f2prateek/rx-receivers)
+
 # Rx Receivers
 
 Reactive `BroadcastReceiver` implementations for Android. 


### PR DESCRIPTION
Added badge for android-gems: http://www.android-gems.com/lib/f2prateek/rx-receivers , it looks like this:

[![Android Gems](http://www.android-gems.com/badge/f2prateek/rx-receivers.svg?branch=master)](http://www.android-gems.com/lib/f2prateek/rx-receivers)

